### PR TITLE
Add REQUIREMENTS_FILE support and zsh setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker run -d \
   -e CF_TUNNEL_TOKEN="<your-cloudflared-token>" \
   -e JUPYTER_TOKEN="<your-jupyter-token>" \
   -e PASSWORD="<your-vscode-password>" \
+  -e REQUIREMENTS_FILE="/workspace/requirements.txt" \
   chaichy/jupyter-code-container:cpu
 ```
 
@@ -42,6 +43,7 @@ docker run -d --gpus all \
   -e CF_TUNNEL_TOKEN="<your-cloudflared-token>" \
   -e JUPYTER_TOKEN="<your-jupyter-token>" \
   -e PASSWORD="<your-vscode-password>" \
+  -e REQUIREMENTS_FILE="/workspace/requirements.txt" \
   chaichy/jupyter-code-container:gpu
 ```
 
@@ -78,6 +80,7 @@ Want a full dev environment in the cloud in minutes?
 - **Auto-installed VS Code Extensions**: Python, Jupyter.
 - **Mount your code**: Mount a local folder to `/workspace` for editing and notebooks.
 - **Pre-configured VS Code ↔ Jupyter integration**.
+- **Zsh shell** with Oh My Zsh and automatic Conda activation.
 
 ---
 
@@ -134,6 +137,7 @@ docker run -d \
   -e CF_TUNNEL_TOKEN="<your-cloudflared-token>" \
   -e JUPYTER_TOKEN="<your-jupyter-token>" \
   -e PASSWORD="<your-vscode-password>" \
+  -e REQUIREMENTS_FILE="/workspace/requirements.txt" \
   chaichy/jupyter-code-container:latest
 ```
 
@@ -141,6 +145,7 @@ docker run -d \
 - `CF_TUNNEL_TOKEN`: [Get it here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
 - `JUPYTER_TOKEN`: Password token for JupyterLab
 - `PASSWORD`: Password for VS Code
+- `REQUIREMENTS_FILE`: Optional path to additional requirements
 
 Access your services:
 
@@ -157,6 +162,7 @@ Access your services:
 | `JUPYTER_TOKEN`   | Token to secure JupyterLab                                            |
 | `PASSWORD`        | Password to secure code-server                                        |
 | `TARGETARCH`      | (Optional) Docker build arg for architecture (`amd64`, `arm64`)       |
+| `REQUIREMENTS_FILE` | (Optional) Path to a `requirements.txt` installed on startup |
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CF_TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
       - JUPYTER_TOKEN=${JUPYTER_TOKEN}
       - PASSWORD=${PASSWORD}
+      - REQUIREMENTS_FILE=${REQUIREMENTS_FILE}
     ports:
       - "8080:8080"
       - "8888:8888"
@@ -34,6 +35,7 @@ services:
       - CF_TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
       - JUPYTER_TOKEN=${JUPYTER_TOKEN}
       - PASSWORD=${PASSWORD}
+      - REQUIREMENTS_FILE=${REQUIREMENTS_FILE}
     ports:
       - "8081:8080"
       - "8889:8888"

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -5,14 +5,15 @@ FROM codercom/code-server:latest
 
 ARG TARGETARCH=amd64
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH="/opt/conda/bin:${PATH}"
+    PATH="/opt/conda/bin:${PATH}" \
+    SHELL=/bin/zsh
 
 USER root
 
 # 1) System deps + Miniforge
 RUN apt-get update && apt-get install -y \
-      curl git ca-certificates bzip2 && \
-    rm -rf /var/lib/apt/lists/* && \
+      curl git ca-certificates bzip2 zsh && \
+      rm -rf /var/lib/apt/lists/* && \
     curl -fsSL \
       "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" \
       -o /tmp/conda.sh && \
@@ -33,7 +34,13 @@ COPY config/ /home/coder/.config/
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
-RUN chown -R coder:coder /home/coder
+RUN curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh \
+      -o /tmp/ohmyzsh_install.sh \
+ && chmod +x /tmp/ohmyzsh_install.sh \
+ && su - coder -c "/tmp/ohmyzsh_install.sh --unattended" \
+ && echo '. /opt/conda/etc/profile.d/conda.sh && conda activate' >> /home/coder/.zshrc \
+ && usermod --shell /bin/zsh coder \
+ && rm /tmp/ohmyzsh_install.sh
 
 # 5) VS Code extensions
 USER coder

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -6,6 +6,7 @@ FROM pytorch/pytorch:2.7.0-cuda11.8-cudnn9-runtime
 ARG TARGETARCH=amd64
 ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/opt/conda/bin:${PATH}" \
+    SHELL=/bin/zsh \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
@@ -16,8 +17,8 @@ RUN groupadd -r coder && \
 
 # 1) System deps
 RUN apt-get update && apt-get install -y \
-      curl git ca-certificates bzip2 && \
-    rm -rf /var/lib/apt/lists/*
+      curl git ca-certificates bzip2 zsh && \
+      rm -rf /var/lib/apt/lists/*
 
 # 2) Python env (same shared deps)
 COPY config/environment.yml /tmp/environment.yml
@@ -31,7 +32,13 @@ RUN curl -fsSL \
 COPY config/ /root/.config/
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
-RUN chown -R coder:coder /home/coder
+RUN curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh \
+      -o /tmp/ohmyzsh_install.sh \
+ && chmod +x /tmp/ohmyzsh_install.sh \
+ && su - coder -c "/tmp/ohmyzsh_install.sh --unattended" \
+ && echo '. /opt/conda/etc/profile.d/conda.sh && conda activate' >> /home/coder/.zshrc \
+ && usermod --shell /bin/zsh coder \
+ && rm /tmp/ohmyzsh_install.sh
 
 # 4) VS Code extensions
 RUN curl -fsSL https://code-server.dev/install.sh | sh 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,6 +18,12 @@ cat > "${CONFIG_DIR}/settings.json" <<EOF
 EOF
 chown coder:coder "${CONFIG_DIR}/settings.json"
 
+# Optional additional requirements
+if [ -n "${REQUIREMENTS_FILE:-}" ] && [ -f "${REQUIREMENTS_FILE}" ]; then
+  echo "Installing packages from ${REQUIREMENTS_FILE}"
+  pip install --no-cache-dir -r "${REQUIREMENTS_FILE}"
+fi
+
 # Start ephemeral Cloudflare tunnel using token
 cloudflared tunnel run --token "${CF_TUNNEL_TOKEN}" &
 


### PR DESCRIPTION
## Summary
- install Oh My Zsh via the recommended installer script
- automatically activate conda in zsh
- allow optional installation of additional pip requirements via `REQUIREMENTS_FILE`
- document new variable and shell in README
- extend docker-compose with the variable

## Testing
- `make` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686503820740832e83bde22bf3235c7d